### PR TITLE
Feature/service directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker compose -f compose-dev.yml up
 Then you must run the migration and seeder inside the app container.
 
 ```bash
-docker compose -f compose-dev.yml exec app  bash
+docker compose -f compose-dev.yml exec app bash
 ```
 
 And you must first run the migrations using the cli

--- a/internal/dto/directory_tree/create.go
+++ b/internal/dto/directory_tree/create.go
@@ -1,12 +1,11 @@
 package dto
 
 type CreateDirectoryTreeReq struct {
-	DirectoryId int64 `json:"directoryId" validate:"required"`
-	RoleId      int64 `json:"roleId" validate:"required"`
+	ParentID int64  `json:"parentId" validate:"required"`
+	Name     string `json:"name" validate:"required"`
 }
 
 type CreateDirectoryTreeRes struct {
 	Id          int64 `json:"id"`
 	DirectoryId int64 `json:"directoryId"`
-	RoleId      int64 `json:"roleId"`
 }

--- a/internal/dto/directory_tree/create.go
+++ b/internal/dto/directory_tree/create.go
@@ -1,11 +1,13 @@
 package dto
 
 type CreateDirectoryTreeReq struct {
-	ParentID int64  `json:"parentId" validate:"required"`
+	ParentID int64  `json:"parentId"`
 	Name     string `json:"name" validate:"required"`
 }
 
 type CreateDirectoryTreeRes struct {
-	Id          int64 `json:"id"`
-	DirectoryId int64 `json:"directoryId"`
+	Id          int64  `json:"id"`
+	DirectoryId int64  `json:"directoryId"`
+	ParentID    int64  `json:"parentId"`
+	Name        string `json:"name`
 }

--- a/internal/dto/directory_tree/create.go
+++ b/internal/dto/directory_tree/create.go
@@ -1,11 +1,11 @@
 package dto
 
-type CreateDirectoryRoleReq struct {
+type CreateDirectoryTreeReq struct {
 	DirectoryId int64 `json:"directoryId" validate:"required"`
 	RoleId      int64 `json:"roleId" validate:"required"`
 }
 
-type CreateDirectoryRoleRes struct {
+type CreateDirectoryTreeRes struct {
 	Id          int64 `json:"id"`
 	DirectoryId int64 `json:"directoryId"`
 	RoleId      int64 `json:"roleId"`

--- a/internal/dto/directory_tree/get.go
+++ b/internal/dto/directory_tree/get.go
@@ -5,6 +5,7 @@ type GetDirectoryTreeReq struct {
 }
 
 type GetDirectoryTreeRes struct {
-	Id          int64 `json:"id"`
-	DirectoryId int64 `json:"directoryId"`
+	Id       int64  `json:"id"`
+	ParentID int64  `json:"directoryId"`
+	Name     string `jston:name`
 }

--- a/internal/dto/directory_tree/get.go
+++ b/internal/dto/directory_tree/get.go
@@ -1,10 +1,10 @@
 package dto
 
-type GetDirectoryRoleReq struct {
+type GetDirectoryTreeReq struct {
 	Id int64 `json:"id" validate:"required"`
 }
 
-type GetDirectoryRoleRes struct {
+type GetDirectoryTreeRes struct {
 	Id          int64 `json:"id"`
 	DirectoryId int64 `json:"directoryId"`
 	RoleId      int64 `json:"roleId"`

--- a/internal/dto/directory_tree/get.go
+++ b/internal/dto/directory_tree/get.go
@@ -7,5 +7,4 @@ type GetDirectoryTreeReq struct {
 type GetDirectoryTreeRes struct {
 	Id          int64 `json:"id"`
 	DirectoryId int64 `json:"directoryId"`
-	RoleId      int64 `json:"roleId"`
 }

--- a/internal/handler/directory_tree.go
+++ b/internal/handler/directory_tree.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	dto "optitech/internal/dto"
+	ddto "optitech/internal/dto/directory_tree"
 	"optitech/internal/interfaces"
 
 	"github.com/gofiber/fiber/v2"
@@ -17,9 +19,35 @@ func NewHnadlerDirectoryTree(r interfaces.IDirectoryService) interfaces.IDirecto
 }
 
 func (h *handlerDirectoryTree) Get(c *fiber.Ctx) error {
-	return nil
+	params := c.AllParams()
+	req := &ddto.GetDirectoryTreeReq{}
+	if err := dto.ValidateParamsToDTO(params, req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	res, err := h.directoryTreeService.Get(*req)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(res)
 }
 
 func (h *handlerDirectoryTree) Create(c *fiber.Ctx) error {
-	return nil
+	req := &ddto.CreateDirectoryTreeReq{}
+
+	if err := c.BodyParser(req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid input: "+err.Error())
+	}
+
+	if err := dto.ValidateDTO(req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	res, err := h.directoryTreeService.Create(req)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(res)
 }

--- a/internal/handler/directory_tree.go
+++ b/internal/handler/directory_tree.go
@@ -51,3 +51,12 @@ func (h *handlerDirectoryTree) Create(c *fiber.Ctx) error {
 
 	return c.JSON(res)
 }
+
+func (h *handlerDirectoryTree) List(c *fiber.Ctx) error {
+	res, err := h.directoryTreeService.List()
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(res)
+}

--- a/internal/handler/directory_tree.go
+++ b/internal/handler/directory_tree.go
@@ -12,7 +12,7 @@ type handlerDirectoryTree struct {
 	directoryTreeService interfaces.IDirectoryService
 }
 
-func NewHnadlerDirectoryTree(r interfaces.IDirectoryService) interfaces.IDirectoryHandler {
+func NewHandlerDirectoryTree(r interfaces.IDirectoryService) interfaces.IDirectoryHandler {
 	return &handlerDirectoryTree{
 		directoryTreeService: r,
 	}
@@ -37,7 +37,7 @@ func (h *handlerDirectoryTree) Create(c *fiber.Ctx) error {
 	req := &ddto.CreateDirectoryTreeReq{}
 
 	if err := c.BodyParser(req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid input: "+err.Error())
+		return fiber.NewError(fiber.StatusBadRequest, "Entrada inválida: "+err.Error())
 	}
 
 	if err := dto.ValidateDTO(req); err != nil {

--- a/internal/handler/directory_tree.go
+++ b/internal/handler/directory_tree.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"optitech/internal/interfaces"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type handlerDirectoryTree struct {
+	directoryTreeService interfaces.IDirectoryService
+}
+
+func NewHnadlerDirectoryTree(r interfaces.IDirectoryService) interfaces.IDirectoryHandler {
+	return &handlerDirectoryTree{
+		directoryTreeService: r,
+	}
+}
+
+func (h *handlerDirectoryTree) Get(c *fiber.Ctx) error {
+	return nil
+}
+
+func (h *handlerDirectoryTree) Create(c *fiber.Ctx) error {
+	return nil
+}

--- a/internal/handler/directory_tree.go
+++ b/internal/handler/directory_tree.go
@@ -60,3 +60,19 @@ func (h *handlerDirectoryTree) List(c *fiber.Ctx) error {
 
 	return c.JSON(res)
 }
+
+func (h *handlerDirectoryTree) Delete(c *fiber.Ctx) error {
+	params := c.AllParams()
+	req := &ddto.GetDirectoryTreeReq{}
+	if err := dto.ValidateParamsToDTO(params, req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	res, err := h.directoryTreeService.Delete(*req)
+
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(res)
+}

--- a/internal/interfaces/directory_tree.go
+++ b/internal/interfaces/directory_tree.go
@@ -11,16 +11,19 @@ type IDirectoryService interface {
 	Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error)
 	Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
 	List() (*[]dto.GetDirectoryTreeRes, error)
+	Delete(req dto.GetDirectoryTreeReq) (bool, error)
 }
 
 type IDirectoryRepository interface {
 	GetDirectory(directoryID int64) (*dto.GetDirectoryTreeRes, error)
 	CreateDirectory(arg *models.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error)
 	ListDirectory() (*[]dto.GetDirectoryTreeRes, error)
+	DeleteDirectory(arg *models.DeleteDirectoryTreeByIdParams) error
 }
 
 type IDirectoryHandler interface {
 	Get(c *fiber.Ctx) error
 	Create(c *fiber.Ctx) error
 	List(c *fiber.Ctx) error
+	Delete(c *fiber.Ctx) error
 }

--- a/internal/interfaces/directory_tree.go
+++ b/internal/interfaces/directory_tree.go
@@ -9,7 +9,7 @@ import (
 
 type IDirectoryService interface {
 	Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error)
-	Create(req dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
+	Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
 }
 
 type IDirectoryRepositoy interface {

--- a/internal/interfaces/directory_tree.go
+++ b/internal/interfaces/directory_tree.go
@@ -12,9 +12,9 @@ type IDirectoryService interface {
 	Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
 }
 
-type IDirectoryRepositoy interface {
-	GetDirectroy(directoryID int64) (*dto.GetDirectoryTreeRes, error)
-	CreateDirectoy(arg *models.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error)
+type IDirectoryRepository interface {
+	GetDirectory(directoryID int64) (*dto.GetDirectoryTreeRes, error)
+	CreateDirectory(arg *models.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error)
 }
 
 type IDirectoryHandler interface {

--- a/internal/interfaces/directory_tree.go
+++ b/internal/interfaces/directory_tree.go
@@ -1,0 +1,23 @@
+package interfaces
+
+import (
+	dto "optitech/internal/dto/directory_tree"
+	models "optitech/internal/sqlc"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type IDirectoryService interface {
+	Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error)
+	Create(req dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
+}
+
+type IDirectoryRepositoy interface {
+	GetDirectroy(directoryID int64) (*dto.GetDirectoryTreeRes, error)
+	CreateDirectoy(arg *models.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error)
+}
+
+type IDirectoryHandler interface {
+	Get(c *fiber.Ctx) error
+	Create(c *fiber.Ctx) error
+}

--- a/internal/interfaces/directory_tree.go
+++ b/internal/interfaces/directory_tree.go
@@ -10,14 +10,17 @@ import (
 type IDirectoryService interface {
 	Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error)
 	Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error)
+	List() (*[]dto.GetDirectoryTreeRes, error)
 }
 
 type IDirectoryRepository interface {
 	GetDirectory(directoryID int64) (*dto.GetDirectoryTreeRes, error)
 	CreateDirectory(arg *models.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error)
+	ListDirectory() (*[]dto.GetDirectoryTreeRes, error)
 }
 
 type IDirectoryHandler interface {
 	Get(c *fiber.Ctx) error
 	Create(c *fiber.Ctx) error
+	List(c *fiber.Ctx) error
 }

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	dto "optitech/internal/dto/directory_tree"
+	"optitech/internal/interfaces"
+	sq "optitech/internal/sqlc"
+)
+
+type repositoryDirectoryTree struct {
+	directoryRepository *sq.Queries
+}
+
+func NewRepositoryDirectoryTree(q *sq.Queries) interfaces.IDirectoryRepositoy {
+	return &repositoryDirectoryTree{
+		directoryRepository: q,
+	}
+}
+
+func (r *repositoryDirectoryTree) GetDirectroy(directoryID int64) (*dto.GetDirectoryTreeRes, error) {
+	return nil, nil
+}
+
+func (r *repositoryDirectoryTree) CreateDirectoy(arg *sq.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error) {
+	return nil, nil
+}

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -27,8 +27,9 @@ func (r *repositoryDirectoryTree) GetDirectory(directoryID int64) (*dto.GetDirec
 	}
 
 	return &dto.GetDirectoryTreeRes{
-		Id:          repoRes.DirectoryID,
-		DirectoryId: repoRes.DirectoryID,
+		Id:       repoRes.DirectoryID,
+		ParentID: int64(repoRes.ParentID.Int32),
+		Name:     repoRes.Name.String,
 	}, nil
 }
 

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -67,5 +67,9 @@ func (r *repositoryDirectoryTree) ListDirectory() (*[]dto.GetDirectoryTreeRes, e
 		}
 	}
 	return &directorys, nil
+}
 
+func (r *repositoryDirectoryTree) DeleteDirectory(arg *sq.DeleteDirectoryTreeByIdParams) error {
+	ctx := context.Background()
+	return r.directoryRepository.DeleteDirectoryTreeById(ctx, *arg)
 }

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -49,3 +49,23 @@ func (r *repositoryDirectoryTree) CreateDirectory(arg *sq.CreateDirectoryTreePar
 		Name:        res.Name.String,
 	}, nil
 }
+
+func (r *repositoryDirectoryTree) ListDirectory() (*[]dto.GetDirectoryTreeRes, error) {
+	ctx := context.Background()
+	repoRes, err := r.directoryRepository.ListDirectoryTrees(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	directorys := make([]dto.GetDirectoryTreeRes, len(repoRes))
+	for i, inst := range repoRes {
+		directorys[i] = dto.GetDirectoryTreeRes{
+			Id:       inst.DirectoryID,
+			ParentID: int64(inst.ParentID.Int32),
+			Name:     inst.Name.String,
+		}
+	}
+	return &directorys, nil
+
+}

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	dto "optitech/internal/dto/directory_tree"
 	"optitech/internal/interfaces"
 	sq "optitech/internal/sqlc"
@@ -17,9 +18,31 @@ func NewRepositoryDirectoryTree(q *sq.Queries) interfaces.IDirectoryRepositoy {
 }
 
 func (r *repositoryDirectoryTree) GetDirectroy(directoryID int64) (*dto.GetDirectoryTreeRes, error) {
-	return nil, nil
+	ctx := context.Background()
+
+	repoRes, err := r.directoryRepository.GetDirectoryTree(ctx, (directoryID))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.GetDirectoryTreeRes{
+		Id:          repoRes.DirectoryID,
+		DirectoryId: repoRes.DirectoryID,
+	}, nil
 }
 
 func (r *repositoryDirectoryTree) CreateDirectoy(arg *sq.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error) {
-	return nil, nil
+	ctx := context.Background()
+
+	res, err := r.directoryRepository.CreateDirectoryTree(ctx, *arg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.CreateDirectoryTreeRes{
+		Id:          res.DirectoryID,
+		DirectoryId: res.DirectoryID,
+	}, nil
 }

--- a/internal/repository/directory_tree.go
+++ b/internal/repository/directory_tree.go
@@ -11,16 +11,16 @@ type repositoryDirectoryTree struct {
 	directoryRepository *sq.Queries
 }
 
-func NewRepositoryDirectoryTree(q *sq.Queries) interfaces.IDirectoryRepositoy {
+func NewRepositoryDirectoryTree(q *sq.Queries) interfaces.IDirectoryRepository {
 	return &repositoryDirectoryTree{
 		directoryRepository: q,
 	}
 }
 
-func (r *repositoryDirectoryTree) GetDirectroy(directoryID int64) (*dto.GetDirectoryTreeRes, error) {
+func (r *repositoryDirectoryTree) GetDirectory(directoryID int64) (*dto.GetDirectoryTreeRes, error) {
 	ctx := context.Background()
 
-	repoRes, err := r.directoryRepository.GetDirectoryTree(ctx, (directoryID))
+	repoRes, err := r.directoryRepository.GetDirectoryTree(ctx, directoryID)
 
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (r *repositoryDirectoryTree) GetDirectroy(directoryID int64) (*dto.GetDirec
 	}, nil
 }
 
-func (r *repositoryDirectoryTree) CreateDirectoy(arg *sq.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error) {
+func (r *repositoryDirectoryTree) CreateDirectory(arg *sq.CreateDirectoryTreeParams) (*dto.CreateDirectoryTreeRes, error) {
 	ctx := context.Background()
 
 	res, err := r.directoryRepository.CreateDirectoryTree(ctx, *arg)
@@ -44,5 +44,7 @@ func (r *repositoryDirectoryTree) CreateDirectoy(arg *sq.CreateDirectoryTreePara
 	return &dto.CreateDirectoryTreeRes{
 		Id:          res.DirectoryID,
 		DirectoryId: res.DirectoryID,
+		ParentID:    int64(res.ParentID.Int32),
+		Name:        res.Name.String,
 	}, nil
 }

--- a/internal/router/directory_tree.go
+++ b/internal/router/directory_tree.go
@@ -1,0 +1,19 @@
+package router
+
+import (
+	"optitech/internal/handler"
+	"optitech/internal/repository"
+	dts "optitech/internal/service/directory_tree"
+)
+
+func (s *Server) RoutesDirectoryClient() {
+	r := s.app
+	repoService := repository.NewRepositoryDirectoryTree(&repository.Queries)
+	service := dts.NewServicDirectory(repoService)
+	handler := handler.NewHnadlerDirectoryTree(service)
+	serviceRoute := r.Group("/api/directory-tree")
+
+	serviceRoute.Get("/", handler.Get)
+	serviceRoute.Post("/", handler.Create)
+
+}

--- a/internal/router/directory_tree.go
+++ b/internal/router/directory_tree.go
@@ -16,4 +16,5 @@ func (s *Server) RoutesDirectoryTree() {
 	serviceRoute.Get("/all", handler.List)
 	serviceRoute.Get("/:id", handler.Get)
 	serviceRoute.Post("/", handler.Create)
+	serviceRoute.Delete("/delete/:id", handler.Delete)
 }

--- a/internal/router/directory_tree.go
+++ b/internal/router/directory_tree.go
@@ -13,6 +13,6 @@ func (s *Server) RoutesDirectoryTree() {
 	handler := handler.NewHandlerDirectoryTree(service)
 	serviceRoute := r.Group("/api/directory-tree")
 
-	serviceRoute.Get("/", handler.Get)
+	serviceRoute.Get("/:id", handler.Get)
 	serviceRoute.Post("/", handler.Create)
 }

--- a/internal/router/directory_tree.go
+++ b/internal/router/directory_tree.go
@@ -13,6 +13,7 @@ func (s *Server) RoutesDirectoryTree() {
 	handler := handler.NewHandlerDirectoryTree(service)
 	serviceRoute := r.Group("/api/directory-tree")
 
+	serviceRoute.Get("/all", handler.List)
 	serviceRoute.Get("/:id", handler.Get)
 	serviceRoute.Post("/", handler.Create)
 }

--- a/internal/router/directory_tree.go
+++ b/internal/router/directory_tree.go
@@ -6,14 +6,13 @@ import (
 	dts "optitech/internal/service/directory_tree"
 )
 
-func (s *Server) RoutesDirectoryClient() {
+func (s *Server) RoutesDirectoryTree() {
 	r := s.app
 	repoService := repository.NewRepositoryDirectoryTree(&repository.Queries)
-	service := dts.NewServicDirectory(repoService)
-	handler := handler.NewHnadlerDirectoryTree(service)
+	service := dts.NewServiceDirectory(repoService)
+	handler := handler.NewHandlerDirectoryTree(service)
 	serviceRoute := r.Group("/api/directory-tree")
 
 	serviceRoute.Get("/", handler.Get)
 	serviceRoute.Post("/", handler.Create)
-
 }

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -20,6 +20,7 @@ func (s *Server) ListenAndServe() error {
 	s.RoutesServices()
 	s.RoutesInstitution()
 	s.RoutesInstitutionClient()
+	s.RoutesDirectoryTree()
 	err := s.app.Listen(fmt.Sprintf(":%d", s.Port))
 
 	if err != nil {

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -52,3 +52,16 @@ func (s *serviceDirectoryTree) List() (*[]dto.GetDirectoryTreeRes, error) {
 	}
 	return repoRes, nil
 }
+
+func (s *serviceDirectoryTree) Delete(req dto.GetDirectoryTreeReq) (bool, error) {
+	repoReq := &sq.DeleteDirectoryTreeByIdParams{
+		DirectoryID: req.Id,
+		DeletedAt:   pgtype.Timestamp{Time: time.Now(), Valid: true},
+	}
+
+	if err := s.directoryTreeRepository.DeleteDirectory(repoReq); err != nil {
+		return false, pgtype.ErrScanTargetTypeChanged
+	}
+
+	return true, nil
+}

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -23,7 +23,7 @@ func (s *serviceDirectoryTree) Get(req dto.GetDirectoryTreeReq) (*dto.GetDirecto
 	return s.directoryTreeRepository.GetDirectroy(req.Id)
 }
 
-func (s *serviceDirectoryTree) Create(req dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
+func (s *serviceDirectoryTree) Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
 	repoReq := &sq.CreateDirectoryTreeParams{
 		ParentID:  pgtype.Int4{Int32: int32(req.ParentID), Valid: true},
 		Name:      pgtype.Text{String: req.Name, Valid: true},

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	dto "optitech/internal/dto/directory_tree"
+	"optitech/internal/interfaces"
+)
+
+type serviceDirectoryTree struct {
+	directoryTreeRepository interfaces.IDirectoryRepositoy
+}
+
+func NewServicDirectory(r interfaces.IDirectoryRepositoy) interfaces.IDirectoryService {
+	return &serviceDirectoryTree{
+		directoryTreeRepository: r,
+	}
+}
+
+func (s *serviceDirectoryTree) Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error) {
+	return s.directoryTreeRepository.GetDirectroy(req.Id)
+}
+
+func (s *serviceDirectoryTree) Create(req dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
+	return nil, nil
+}

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -3,6 +3,10 @@ package service
 import (
 	dto "optitech/internal/dto/directory_tree"
 	"optitech/internal/interfaces"
+	sq "optitech/internal/sqlc"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type serviceDirectoryTree struct {
@@ -20,5 +24,18 @@ func (s *serviceDirectoryTree) Get(req dto.GetDirectoryTreeReq) (*dto.GetDirecto
 }
 
 func (s *serviceDirectoryTree) Create(req dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
-	return nil, nil
+	repoReq := &sq.CreateDirectoryTreeParams{
+		ParentID:  pgtype.Int4{Int32: int32(req.ParentID), Valid: true},
+		Name:      pgtype.Text{String: req.Name, Valid: true},
+		CreatedAt: pgtype.Timestamp{Time: time.Now(), Valid: true},
+	}
+
+	r, err := s.directoryTreeRepository.CreateDirectoy(repoReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Ubicar el token si es requerido
+
+	return r, nil
 }

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -44,3 +44,11 @@ func (s *serviceDirectoryTree) Create(req *dto.CreateDirectoryTreeReq) (*dto.Cre
 
 	return r, nil
 }
+
+func (s *serviceDirectoryTree) List() (*[]dto.GetDirectoryTreeRes, error) {
+	repoRes, err := s.directoryTreeRepository.ListDirectory()
+	if err != nil {
+		return nil, err
+	}
+	return repoRes, nil
+}

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -26,7 +26,7 @@ func (s *serviceDirectoryTree) Get(req dto.GetDirectoryTreeReq) (*dto.GetDirecto
 func (s *serviceDirectoryTree) Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
 	var parentID pgtype.Int4
 	if req.ParentID == 0 {
-		parentID = pgtype.Int4{Valid: false} // Asignar null si ParentID es 0
+		parentID = pgtype.Int4{Valid: false}
 	} else {
 		parentID = pgtype.Int4{Int32: int32(req.ParentID), Valid: true}
 	}

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -10,32 +10,37 @@ import (
 )
 
 type serviceDirectoryTree struct {
-	directoryTreeRepository interfaces.IDirectoryRepositoy
+	directoryTreeRepository interfaces.IDirectoryRepository
 }
 
-func NewServicDirectory(r interfaces.IDirectoryRepositoy) interfaces.IDirectoryService {
+func NewServiceDirectory(r interfaces.IDirectoryRepository) interfaces.IDirectoryService {
 	return &serviceDirectoryTree{
 		directoryTreeRepository: r,
 	}
 }
 
 func (s *serviceDirectoryTree) Get(req dto.GetDirectoryTreeReq) (*dto.GetDirectoryTreeRes, error) {
-	return s.directoryTreeRepository.GetDirectroy(req.Id)
+	return s.directoryTreeRepository.GetDirectory(req.Id)
 }
 
 func (s *serviceDirectoryTree) Create(req *dto.CreateDirectoryTreeReq) (*dto.CreateDirectoryTreeRes, error) {
+	var parentID pgtype.Int4
+	if req.ParentID == 0 {
+		parentID = pgtype.Int4{Valid: false} // Asignar null si ParentID es 0
+	} else {
+		parentID = pgtype.Int4{Int32: int32(req.ParentID), Valid: true}
+	}
+
 	repoReq := &sq.CreateDirectoryTreeParams{
-		ParentID:  pgtype.Int4{Int32: int32(req.ParentID), Valid: true},
+		ParentID:  parentID,
 		Name:      pgtype.Text{String: req.Name, Valid: true},
 		CreatedAt: pgtype.Timestamp{Time: time.Now(), Valid: true},
 	}
 
-	r, err := s.directoryTreeRepository.CreateDirectoy(repoReq)
+	r, err := s.directoryTreeRepository.CreateDirectory(repoReq)
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: Ubicar el token si es requerido
 
 	return r, nil
 }


### PR DESCRIPTION
# Directory-tree carpeta raíz y carpeta dentro de carpeta.

## Description
Este PR contiene:
- Creación de servicio `Directory Tree`
- Crear carpeta raíz `/`
- Crear carpeta dentro de carpeta

![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/6e05a63f-3bbf-449f-b9f6-a6f0d831cb8e)

![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/f2782229-ad14-4004-9ea5-cc446221c148)

### Summary
Se realizó el servicio básico de `Directory tree`, donde tiene `Get` `Create` `List` y `Delete`
Junto a esto, la funcionalidad de Crear carpeta raíz (No se autorreferencia en DB) y crear Carpeta dentro de carpeta (sé autorreferencia).

#### DTO's
Se modificaron los DTO de `Create` y `Get`.
Para que deje ingresar el `parentID` de forma no obligatoria y así poder crear la carpeta raíz
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/ccdd170c-a600-45bb-b7ae-84b77be38922)

![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/820de156-be8b-4f05-9ff6-77a321fac43a)


#### Postman
Con postman sé probo el funcionamiento correcto de las peticiones.
- POST: http://localhost:3000/api/directory-tree/
-- Creando Raiz
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/b2ac59f9-82d0-4e46-a656-15c4b75edc11)

-- Carpeta dento de Carpeta
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/f30180ba-8de9-4d43-b0c4-49265c878e4c)

- GET: http://localhost:3000/api/directory-tree/:id
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/65544cc2-1994-44ed-9a5e-84fd39bc192c)

- GET: http://localhost:3000/api/directory-tree/all
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/5006044f-8f32-48f1-9195-f30466242951)

- DELETE: http://localhost:3000/api/directory-tree/delete/:id
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/80cb77c8-ead4-4a5f-81ae-4e4eab83981c)
![imagen](https://github.com/OwlByTech/optitech-api/assets/126360945/ae769a98-8226-466f-9e79-ad48132406ee)


## How Has This Been Tested?
Por medio de postman se testeó el funcionamiento, pero no contiene test formal.

## Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules