### PR TITLE
Feature/move file

### DIFF
--- a/database/queries/directory_tree.sql
+++ b/database/queries/directory_tree.sql
@@ -50,7 +50,7 @@ SELECT * FROM directory;
 
 -- name: UpdateDirectoryTreeById :exec
 UPDATE directory_tree
-SET name = $2, updated_at = $3
+SET name = $2, updated_at = $3, parent_id = $4
 WHERE directory_id = $1;
 
 -- name: GetInstitutionNameByDirectoryId :one

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"log"
 	dto "optitech/internal/dto/directory_tree"
 	"optitech/internal/interfaces"
 	sq "optitech/internal/sqlc"
@@ -206,8 +205,6 @@ func (s *serviceDirectoryTree) Delete(req dto.GetDirectoryTreeReq) (bool, error)
 func (s *serviceDirectoryTree) Update(req *dto.UpdateDirectoryTreeReq) (bool, error) {
 	directory, err := s.Get(dto.GetDirectoryTreeReq{Id: req.DirectoryId, InstitutionID: req.InstitutionID})
 
-	log.Print(directory)
-
 	if err != nil {
 		return false, err
 	}
@@ -216,10 +213,17 @@ func (s *serviceDirectoryTree) Update(req *dto.UpdateDirectoryTreeReq) (bool, er
 		DirectoryID: req.DirectoryId,
 		Name:        pgtype.Text{String: directory.Name, Valid: true},
 		UpdatedAt:   pgtype.Timestamp{Time: time.Now(), Valid: true},
+		ParentID:    pgtype.Int8{Int64: directory.ParentID, Valid: true},
 	}
 
 	if req.Name != "" {
 		repoReq.Name = pgtype.Text{String: req.Name, Valid: true}
+	}
+
+	if req.ParentID != 0 {
+		repoReq.ParentID = pgtype.Int8{Int64: req.ParentID, Valid: true}
+	} else {
+		repoReq.ParentID = pgtype.Int8{Int64: directory.ParentID, Valid: true}
 	}
 
 	err = s.directoryTreeRepository.UpdateDirectoryTree(repoReq)

--- a/internal/service/directory_tree/directory_tree.go
+++ b/internal/service/directory_tree/directory_tree.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"errors"
-	"github.com/jackc/pgx/v5/pgtype"
+	"log"
 	dto "optitech/internal/dto/directory_tree"
 	"optitech/internal/interfaces"
 	sq "optitech/internal/sqlc"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type serviceDirectoryTree struct {
@@ -203,6 +205,8 @@ func (s *serviceDirectoryTree) Delete(req dto.GetDirectoryTreeReq) (bool, error)
 
 func (s *serviceDirectoryTree) Update(req *dto.UpdateDirectoryTreeReq) (bool, error) {
 	directory, err := s.Get(dto.GetDirectoryTreeReq{Id: req.DirectoryId, InstitutionID: req.InstitutionID})
+
+	log.Print(directory)
 
 	if err != nil {
 		return false, err

--- a/internal/sqlc/directory_tree.sql.go
+++ b/internal/sqlc/directory_tree.sql.go
@@ -283,7 +283,7 @@ func (q *Queries) ListDirectoryTrees(ctx context.Context) ([]DirectoryTree, erro
 
 const updateDirectoryTreeById = `-- name: UpdateDirectoryTreeById :exec
 UPDATE directory_tree
-SET name = $2, updated_at = $3
+SET name = $2, updated_at = $3, parent_id = $4
 WHERE directory_id = $1
 `
 
@@ -291,9 +291,15 @@ type UpdateDirectoryTreeByIdParams struct {
 	DirectoryID int64            `json:"directory_id"`
 	Name        pgtype.Text      `json:"name"`
 	UpdatedAt   pgtype.Timestamp `json:"updated_at"`
+	ParentID    pgtype.Int8      `json:"parent_id"`
 }
 
 func (q *Queries) UpdateDirectoryTreeById(ctx context.Context, arg UpdateDirectoryTreeByIdParams) error {
-	_, err := q.db.Exec(ctx, updateDirectoryTreeById, arg.DirectoryID, arg.Name, arg.UpdatedAt)
+	_, err := q.db.Exec(ctx, updateDirectoryTreeById,
+		arg.DirectoryID,
+		arg.Name,
+		arg.UpdatedAt,
+		arg.ParentID,
+	)
 	return err
 }


### PR DESCRIPTION
# Mover carpetas

## Description
Se modifica el servicio `directory_tree` para que deje cambiar la ubicación de las carpetas.

https://github.com/user-attachments/assets/55d5e36c-bb62-4049-bdbe-c09f4c9d84e5

### Summary
Solo se modifica el dto `update` y se modifica el sqlc, ahora con el mismo endpoint de update que había anteriormente, se puede usar para mover las carpetas entre directorios.

## Test
Se hizo el test probándolo en el navegador

## Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules