### PR TITLE
fix: Update institution without an advisor

### DIFF
--- a/internal/service/institution/institution.go
+++ b/internal/service/institution/institution.go
@@ -198,6 +198,10 @@ func (s *serviceInstitution) Update(req *dto.UpdateInstitutionReq) (bool, error)
 		}
 	}
 
+	if institution.AsesorId == 0 {
+		repoReq.AsesorID = pgtype.Int4{Valid: false}
+	}
+
 	err = s.institutionRepository.UpdateInstitution(repoReq)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Fix Update institution without an advisor

## Description
Al actualizar los datos de la institución, presentaba un error al no tener un `asesor` asignado a una `institution`, se corrige agregando un condicional que deje pasar esto, si la institución no tiene un asesor asignado.

Se corrigieron y ahora no presentan dicho problema.

## Test
Se hizo el test probándolo en el navegador `hoppscotch`

## Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules